### PR TITLE
Fix admin hook duplication

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -297,12 +297,14 @@ class Plugin {
         
         // Admin-only hooks
         if (\is_admin()) {
-            // Initialize admin interface
-            \add_action('admin_menu', [$this, 'setup_admin_menu']);
-            \add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_assets']);
-            
-            // Settings API hooks
-            \add_action('admin_init', [$this, 'register_settings']);
+            // When the Admin class is instantiated it already hooks into these
+            // actions via Admin::init(). Register them here only when the
+            // Admin component is absent to avoid duplicate callbacks.
+            if (null === $this->admin) {
+                \add_action('admin_menu', [$this, 'setup_admin_menu']);
+                \add_action('admin_enqueue_scripts', [$this, 'enqueue_admin_assets']);
+                \add_action('admin_init', [$this, 'register_settings']);
+            }
         }
 
         // NOTE: Lifecycle hooks are registered in main plugin file to avoid duplication


### PR DESCRIPTION
## Summary
- avoid registering admin hooks twice when Admin class is present

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc89b6668832884b6f9113e0faaec