### PR TITLE
Remove unused uninstall options

### DIFF
--- a/includes/class-uninstaller.php
+++ b/includes/class-uninstaller.php
@@ -89,8 +89,6 @@ class Uninstaller {
             self::PLUGIN_SLUG . '_options',
             self::PLUGIN_SLUG . '_settings',
             'wpvn_db_version',
-            'wpvn_activation_time',
-            'wpvn_plugin_version',
         ];
 
         foreach ($options_to_remove as $option) {


### PR DESCRIPTION
## Summary
- clean up `remove_plugin_options` to only delete known keys

## Testing
- `php -l includes/class-uninstaller.php`
- `find admin includes -name "*.php" -print | xargs -I{} php -l {}`
- `php -l wp-visitor-notify.php`


------
https://chatgpt.com/codex/tasks/task_e_684dc8a633888328a58efdca8e7e34e3